### PR TITLE
Fix/wcag form parameter parsing

### DIFF
--- a/src/servers/dashboard.js
+++ b/src/servers/dashboard.js
@@ -418,7 +418,7 @@ app.get('/api/reports', (req, res) => {
 
 // Start a new crawl
 app.post('/crawl', (req, res) => {
-    const { url, wcagVersion = 'wcag2.1', maxDepth = '2', maxPages = '50' } = req.body;
+    const { url, wcagVersion = '2.1', wcagLevel = 'AA', maxDepth = '2', maxPages = '50' } = req.body;
     
     if (!url) {
         return res.status(400).json({ success: false, error: 'URL is required' });
@@ -431,6 +431,7 @@ app.post('/crawl', (req, res) => {
     activeJobs.set(jobId, {
         url,
         wcagVersion,
+        wcagLevel,
         maxDepth: parseInt(maxDepth),
         maxPages: parseInt(maxPages),
         status: 'running',
@@ -440,13 +441,14 @@ app.post('/crawl', (req, res) => {
     // Start crawl process
     const domain = new URL(url).hostname;
     const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
-    const outputFilename = `${domain}_${wcagVersion}_${timestamp}.json`;
+    const outputFilename = `${domain}_wcag${wcagVersion}_${wcagLevel}_${timestamp}.json`;
     
     const args = [
         '--seed', url,
         '--depth', maxDepth,
         '--max-pages', maxPages,
         '--wcag-version', wcagVersion,
+        '--wcag-level', wcagLevel,
         '--output', outputFilename,
         '--html'  // Generate HTML report
     ];

--- a/src/servers/dashboard.js
+++ b/src/servers/dashboard.js
@@ -358,11 +358,8 @@ function generateDomainReportsHTML(domain) {
 
 // Routes
 app.get('/', (req, res) => {
-    // Generate fresh index.html if it doesn't exist or regenerate it
+    // Serve the dashboard index.html (regenerated on server startup)
     const indexPath = path.join(config.PUBLIC_DIR, 'index.html');
-    if (!fs.existsSync(indexPath)) {
-        generateIndexHTML();
-    }
     res.sendFile(indexPath);
 });
 
@@ -508,4 +505,9 @@ app.listen(PORT, () => {
     console.log(`🚀 CATS Dashboard running at http://localhost:${PORT}`);
     console.log(`📊 View your dashboard: http://localhost:${PORT}`);
     console.log(`📁 Reports directory: ${config.REPORTS_DIR}`);
+    
+    // Always regenerate index.html on server startup
+    console.log('🔄 Regenerating dashboard index.html...');
+    generateIndexHTML();
+    console.log('✅ Dashboard index.html regenerated');
 });

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -39,10 +39,18 @@
                         <div class="form-group">
                             <label for="wcagVersion">WCAG Version:</label>
                             <select id="wcagVersion" name="wcagVersion">
-                                <option value="wcag2.1">WCAG 2.1 AA (Default)</option>
-                                <option value="wcag2.0">WCAG 2.0 AA</option>
-                                <option value="wcag2.2">WCAG 2.2 AA</option>
-                                <option value="wcag21-aaa">WCAG 2.1 AAA</option>
+                                <option value="2.1" selected>WCAG 2.1 (Default)</option>
+                                <option value="2.0">WCAG 2.0</option>
+                                <option value="2.2">WCAG 2.2 (Latest)</option>
+                            </select>
+                        </div>
+                        
+                        <div class="form-group">
+                            <label for="wcagLevel">WCAG Level:</label>
+                            <select id="wcagLevel" name="wcagLevel">
+                                <option value="A">Level A (Basic)</option>
+                                <option value="AA" selected>Level AA (Standard)</option>
+                                <option value="AAA">Level AAA (Enhanced)</option>
                             </select>
                         </div>
                         


### PR DESCRIPTION
## PR Summary:

- ✅ Bug Fix: Resolves "Unknown WCAG version" error by sending correct CLI parameters
- ✅ UX Improvement: Separate WCAG Version and Level dropdowns for granular control
- ✅ Developer Experience: Auto-regeneration of dashboard index.html on server startup
- ✅ Better Filename Generation: Includes both version and level in report filenames

The fix allows users to select any combination like:

- WCAG 2.0 + Level A (basic compliance)
- WCAG 2.1 + Level AAA (comprehensive testing)
- WCAG 2.2 + Level AA (latest standard + recommended level)

And the CLI will receive the correct parameters: --wcag-version 2.1 --wcag-level AA instead of the broken --wcag-version wcag2.1.