### PR TITLE
add permissions for security events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,11 @@ on:
   pull_request:
     branches: [main, develop]
 
-jobs:
+permissions:
+  contents: read
+  security-events: write
+
+  jobs:
   test:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This pull request introduces a configuration update to the GitHub Actions workflow file `.github/workflows/ci.yml`, specifically adding permissions for the workflow.

Workflow configuration:

* Added explicit permissions for the workflow: `contents: read` and `security-events: write`, which help restrict access and enable security event reporting.
