### PR TITLE
Fix/reports newest first

### DIFF
--- a/src/servers/dashboard.js
+++ b/src/servers/dashboard.js
@@ -350,7 +350,7 @@ async function getReportDirectories() {
         domain,
         reportCount: reports.length,
         lastReport: reports.length > 0 ? reports.sort().pop() : null,
-        reportFiles: reports.sort(),
+        reportFiles: reports.sort().reverse(), // Newest first
       }));
     } else {
       // Fallback to local filesystem
@@ -370,7 +370,7 @@ async function getReportDirectories() {
             domain: dirent.name,
             reportCount: reports.length,
             lastReport: reports.length > 0 ? reports.sort().pop() : null,
-            reportFiles: reports.sort(),
+            reportFiles: reports.sort().reverse(), // Newest first
           };
         });
     }
@@ -439,12 +439,16 @@ async function generateDomainReportsListHTML(domain) {
       reports = files
         .map(filePath => path.basename(filePath))
         .filter(fileName => fileName.endsWith('.html'))
-        .sort();
+        .sort()
+        .reverse(); // Newest first
     } else {
       // Fallback to local filesystem
       const domainDir = path.join(config.REPORTS_DIR, domain);
       const files = fs.readdirSync(domainDir);
-      reports = files.filter(file => file.endsWith('.html'));
+      reports = files
+        .filter(file => file.endsWith('.html'))
+        .sort()
+        .reverse(); // Newest first
     }
 
     if (reports.length === 0) {

--- a/src/servers/dashboard.js
+++ b/src/servers/dashboard.js
@@ -346,12 +346,15 @@ async function getReportDirectories() {
         }
       });
 
-      return Array.from(domainMap.entries()).map(([domain, reports]) => ({
-        domain,
-        reportCount: reports.length,
-        lastReport: reports.length > 0 ? reports.sort().pop() : null,
-        reportFiles: reports.sort().reverse(), // Newest first
-      }));
+      return Array.from(domainMap.entries()).map(([domain, reports]) => {
+        const sortedReports = reports.sort().reverse(); // Newest first
+        return {
+          domain,
+          reportCount: reports.length,
+          lastReport: sortedReports.length > 0 ? sortedReports[0] : null,
+          reportFiles: sortedReports,
+        };
+      });
     } else {
       // Fallback to local filesystem
       const reportsDir = config.REPORTS_DIR;
@@ -366,11 +369,12 @@ async function getReportDirectories() {
           const dirPath = path.join(reportsDir, dirent.name);
           const files = fs.readdirSync(dirPath);
           const reports = files.filter(file => file.endsWith('.html'));
+          const sortedReports = reports.sort().reverse(); // Newest first
           return {
             domain: dirent.name,
             reportCount: reports.length,
-            lastReport: reports.length > 0 ? reports.sort().pop() : null,
-            reportFiles: reports.sort().reverse(), // Newest first
+            lastReport: sortedReports.length > 0 ? sortedReports[0] : null,
+            reportFiles: sortedReports,
           };
         });
     }


### PR DESCRIPTION
## Problem
New reports were not appearing on the `/reports/` page after crawl completion. The issue affected all domains with only 1 report, and would show incomplete lists for domains with multiple reports.

## Root Cause
The `.pop()` method mutates arrays by removing the last element. When getting `lastReport`, we were using:
```javascript
lastReport: reports.sort().pop()  // This REMOVES the element!
reportFiles: reports.sort()       // Now has n-1 elements
```
This caused reportFiles to be missing reports.

## Solution
- Sort reports into a variable first
- Use array indexing sortedReports[0] instead of .pop()
- This preserves ALL reports in reportFiles array

## Changes
- getReportDirectories(): Fixed for cloud storage and local filesystem
- Both paths now use non-mutating array access
- Reports are sorted newest-first (reversed)
