### PR TITLE
Add CSS build step to setup instructions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -87,6 +87,7 @@ Install dependencies and start the app locally:
 ```bash
 npm install
 npm run install-browsers
+npm run sass:build  # ⚠️ REQUIRED: Compile SCSS to CSS on first setup
 npm run dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ git clone https://github.com/iamjolly/crawl-and-test.git
 cd crawl-and-test
 npm install
 npm run install-browsers
+npm run sass:build         # compile SCSS to CSS (required for first setup)
 npm run dev                # starts watcher + server (port 3000)
 
 # One-step dev (watch on host + dev container)
@@ -318,14 +319,15 @@ We welcome contributions! Please see our
 1. **Fork** the repository
 2. **Clone** your fork:
    `git clone https://github.com/YOUR_USERNAME/crawl-and-test.git`
-3. **Install dependencies**: `npm install`
-4. **Create a feature branch**: `git checkout -b feature/your-feature-name`
-5. **Make your changes**
-6. **Run tests**: `npm test`
-7. **Run linting**: `npm run lint:fix`
-8. **Commit using conventional commits**:
+3. **Install dependencies**: `npm install && npm run install-browsers`
+4. **Build CSS**: `npm run sass:build` (compiles SCSS to CSS)
+5. **Create a feature branch**: `git checkout -b feature/your-feature-name`
+6. **Make your changes**
+7. **Run tests**: `npm test`
+8. **Run linting**: `npm run lint:fix`
+9. **Commit using conventional commits**:
    `git commit -m "feat: add new feature"`
-9. **Push and create a PR**
+10. **Push and create a PR**
 
 ### Code Quality
 


### PR DESCRIPTION
## Summary

Updates README.md and DEVELOPMENT.md to include the CSS build step (`npm run sass:build`) in setup instructions for new contributors.

## Context

PR #63 removed compiled CSS files from Git tracking (they are build artifacts). This means new contributors must compile SCSS to CSS manually on first setup.

## Changes

### README.md
- **Quick Start - Local Development**: Added `npm run sass:build` step with comment
- **Contributors Section**: Added CSS build as explicit step 4 with explanation

### DEVELOPMENT.md  
- **Local Development**: Added `npm run sass:build` with warning about requirement

## Why This Matters

Without this step, new contributors will see:
- Missing styles on the dashboard
- Broken UI layouts  
- 404 errors for CSS files

This update ensures contributors know to run the build step before starting development.

## Related

- Complements PR #63 (Remove compiled CSS from Git tracking)
- Ensures smooth onboarding for new contributors